### PR TITLE
Fix: Add missing _ValidationScriptsPartial.cshtml and verify its usage

### DIFF
--- a/PayrollApp/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/PayrollApp/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,0 +1,2 @@
+<script src="~/lib/jquery-validation/dist/jquery.validate.min.js"></script>
+<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"></script>


### PR DESCRIPTION
This commit fixes an `InvalidOperationException` caused by a missing `_ValidationScriptsPartial.cshtml` file, which is essential for client-side validation.

- Added the standard `_ValidationScriptsPartial.cshtml` to `Views/Shared`.
- Verified that all `Create.cshtml` and `Edit.cshtml` views correctly reference this partial view in their `Scripts` section, ensuring consistent validation behavior across the application.